### PR TITLE
Add restart: on-failure to Docker Compose Services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     user: "1000:1000"
     environment:
       - GETH_DATA_DIR=/data
+    restart: on-failure   # Automatically restart on failure for better resilience
   op-node:
     build:
       context: .
@@ -34,3 +35,4 @@ services:
     env_file:
       - .env.ink-sepolia
     user: "1000:1000"
+    restart: on-failure   # Automatically restart on failure for better resilience


### PR DESCRIPTION
Added the restart: on-failure policy to op-geth and op-node services in the Docker Compose configuration. This change ensures that both services will automatically restart upon failure, improving resilience and minimizing downtime.