### PR TITLE
chore: mandatory op upgrade

### DIFF
--- a/op-geth/Dockerfile
+++ b/op-geth/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.21 AS build-op-geth
+FROM golang:1.22 AS build-op-geth
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.3
+ENV VERSION=v1.101411.1
 # for verification:
-ENV COMMIT=8af19cf20261c0b62f98cc27da3a268f542822ee
+ENV COMMIT=4539f2d3a77f14bdad362c24e3773dc6aad87d5b
 
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
@@ -13,7 +13,7 @@ RUN git clone $REPO --branch $VERSION --single-branch . && \
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.21 AS run-op-geth
+FROM golang:1.22 AS run-op-geth
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.21 AS build-op-node
+FROM golang:1.22 AS build-op-node
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.3
+ENV VERSION=v1.9.5
 # for verification:
-ENV COMMIT=e81c50de0a51954c64444b849be4768c8116cffb
+ENV COMMIT=5662448279e4fb16e073e00baeb6e458b12a59b2
 
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
@@ -13,7 +13,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 
 RUN cd op-node && make VERSION=$VERSION op-node
 
-FROM golang:1.21
+FROM golang:1.22
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR upgrades the `op-geth` and `op-node` clients to the latest recommended versions.

> ❗ It is strongly recommended for all chain operators to upgrade to this release.

https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.5