### PR TITLE
Readme file update with Cast installation instruction. Needed for progress.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Will shut down the node and WIPE ALL DATA. Proceed with caution!
 
 Run progress.sh to estimate remaining sync time and speed.
 
+Uses `Cast` command from Foundry tool set. Installation instructions here: [Foundry Installation](https://getfoundry.sh/).
+
 ```sh
 ./progress.sh
 ```


### PR DESCRIPTION
The `progress.sh` script requires `Cast` from the Foundry tool set.

Suggest adding this information into the Readme file to help anyone stuck on this point.