### PR TITLE
feat: upgrade node to pectra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ${PORT__HEALTHCHECK_METRICS:-7300}:7300
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.6
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101500.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -31,7 +31,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.10.3
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh


### PR DESCRIPTION
- Upgrade `op-node` and `op-geth` versions to support Pectra upgrade