### PR TITLE
fix: remove snap sync as it's not currently supported

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,6 @@ HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://rpc-gel.inkonchain.com
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################
 
-# Set to "full" to force op-geth to use --syncmode=full
-OP_GETH__SYNCMODE=
-
 # Feel free to customize your image tag if you want, uses "latest" by default
 # See here for all available images: https://hub.docker.com/u/ethereumoptimism
 IMAGE_TAG__DTL=

--- a/README.md
+++ b/README.md
@@ -213,4 +213,3 @@ If you experience "walking back L1Block with curr=0x0000...:0 next=0x0000...:0" 
 
 1. Wait for a few minutes. This issue usually resolves itself after some time.
 2. Restart docker compose: `docker compose down` and `docker compose up -d --build`
-3. If it's still not working, try setting `OP_GETH__SYNCMODE=full` in .env and restart docker compose

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -7,15 +7,6 @@ while [ ! -f /shared/initialized.txt ]; do
   sleep 1
 done
 
-# Determine syncmode based on NODE_TYPE
-if [ -z "$OP_GETH__SYNCMODE" ]; then
-  if [ "$NODE_TYPE" = "full" ]; then
-    export OP_GETH__SYNCMODE="snap"
-  else
-    export OP_GETH__SYNCMODE="full"
-  fi
-fi
-
 # Override Holocene
 if [ ! -z "$OVERRIDE_HOLOCENE" ]; then
   EXTENDED_ARG="$EXTENDED_ARG --override.holocene=$OVERRIDE_HOLOCENE"
@@ -56,6 +47,6 @@ exec geth \
   --nodiscover \
   --gpo.percentile=60 \
   --verbosity=3 \
-  --syncmode="$OP_GETH__SYNCMODE" \
+  --syncmode="full" \
   --gcmode="$NODE_TYPE" \
   $EXTENDED_ARG $@


### PR DESCRIPTION
After chatting with Gelato, I'm removing the snap sync option as it's not currently supported.