### PR TITLE
Update op-node and op-geth to resolve 'payload is on v3 topic, but has non-zero blob gas used'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ${PORT__HEALTHCHECK_METRICS:-7300}:7300
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.4
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.5
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -31,7 +31,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.2
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh


### PR DESCRIPTION
op-node & op-geth for Inkonchain node are on outdated versions. Pushing this so that blocks resume syncing, since my nodes returned 'payload is on v3 topic, but has non-zero blob gas used' errors.